### PR TITLE
Add user info context menu

### DIFF
--- a/src/context_menus/userinfo.ts
+++ b/src/context_menus/userinfo.ts
@@ -1,0 +1,54 @@
+import ContextMenu from "@structures/ContextMenu";
+import DiscordClient from "@structures/DiscordClient";
+import { ColorResolvable, EmbedBuilder, UserContextMenuCommandInteraction } from "discord.js";
+
+export default class UserMenu extends ContextMenu {
+    constructor() {
+        super("User Info", "USER");
+    }
+
+    async onInteraction(interaction: UserContextMenuCommandInteraction, client: DiscordClient) {
+        const member = await interaction.guild.members.fetch(interaction.targetMember.user.id);
+        const embed = new EmbedBuilder()
+            .setColor(member.displayColor as ColorResolvable)
+            .setTitle("User Information")
+            .setFields([
+                {
+                    name: "Username",
+                    value: member.displayName,
+                    inline: true,
+                },
+                {
+                    name: "ID",
+                    value: member.id,
+                    inline: true,
+                },
+                {
+                    name: "Created At",
+                    value: `<t:${member.user.createdAt.valueOf().toString().substring(0, 10)}>`,
+                    inline: true,
+                },
+                {
+                    name: "Joined At",
+                    value: `<t:${member.joinedAt?.valueOf().toString().substring(0, 10)}>`,
+                    inline: true,
+                },
+                {
+                    name: "Type",
+                    value: member.user.bot ? "🤖" : "🧑",
+                    inline: true,
+                },
+                {
+                    name: "Roles",
+                    value: member.roles.cache.size.toString(),
+                    inline: true,
+                },
+            ])
+            .setThumbnail(member.displayAvatarURL());
+        if (member.user.banner) embed.setImage(member.user.bannerURL());
+
+        await interaction.editReply({
+            embeds: [embed],
+        });
+    }
+}


### PR DESCRIPTION
Adds a context menu for showing user info, similar to `/user` command. This resolves #5 

![image](https://user-images.githubusercontent.com/34704796/194567896-fd6a9e13-e5e9-4792-aace-08d186eca55e.png)
